### PR TITLE
first-steps: iucode-tool is unnecessary

### DIFF
--- a/docs/source/first-steps.rst
+++ b/docs/source/first-steps.rst
@@ -173,8 +173,8 @@ Intel
 
 ::
 
-  sudo pacman -S intel-ucode iucode-tool             # Установить микрокод Intel
-  sudo pacman -S amd-ucode iucode-tool               # Установить микрокод AMD
+  sudo pacman -S intel-ucode                         # Установить микрокод Intel
+  sudo pacman -S amd-ucode                           # Установить микрокод AMD
   sudo mkinitcpio -P                                 # Пересобираем наши образы ядра.
   sudo grub-mkconfig -o /boot/grub/grub.cfg          # Обновить загрузчик или можно через grub-customizer.
 


### PR DESCRIPTION
### Как обновляется микрокод?

Согласно документации [The Linux Microcode Loader](https://www.kernel.org/doc/html/latest/x86/microcode.html#early-load-microcode), ядро может обновлять микрокод во время загрузки. Микрокод хранится внутри образов initrd (то есть .img) в файлах `kernel/x86/microcode/GenuineIntel.bin` и `kernel/x86/microcode/AuthenticAMD.bin`. Во время загрузки ядро ​​сканирует файл микрокода. **Если микрокод, соответствующий CPU, будет найден, он будет применен (1)**.

### Откуда взять образы с микрокодом?

Пакеты [intel-ucode](https://archlinux.org/packages/extra/any/intel-ucode/) и [amd-ucode](https://archlinux.org/packages/core/any/amd-ucode/) предоставляют файлы `/boot/intel-ucode.img` и `/boot/amd-ucode.img` соответственно. **Внутри них находится этот самый микрокод (2)**: 
```
$ unar -i intel-ucode.img 
intel-ucode.img: Cpio
  kernel/x86/microcode/GenuineIntel.bin  (4768768 B)... OK.
```
```
$ unar -i amd-ucode.img 
amd-ucode.img: Cpio
  kernel/x86/microcode/AuthenticAMD.bin  (47350 B)... OK.
```

### Зачем тогда нужен iucode-tool?

[ArchWiki](https://wiki.archlinux.org/title/Microcode_(%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9)#%D0%9E%D0%B1%D0%BD%D0%B0%D1%80%D1%83%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_%D0%B4%D0%BE%D1%81%D1%82%D1%83%D0%BF%D0%BD%D0%BE%D0%B3%D0%BE_%D0%BE%D0%B1%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F_%D0%BC%D0%B8%D0%BA%D1%80%D0%BE%D0%BA%D0%BE%D0%B4%D0%B0) гласит, что с помощью iucode-tool можно узнать, содержит ли образ микрокод для вашего CPU. Во время загрузки ядро делает то же самое (1).
С помощью iucode-tool [создаётся](https://github.com/archlinux/svntogit-packages/blob/4d74f38c4e46d0b731df39873e4c6580e862db93/trunk/PKGBUILD#L20) образ intel-ucode.img и собирается готовый (2) пакет intel-ucode для репозитория.
Можно производить [различные манипуляции](https://man.archlinux.org/man/extra/iucode-tool/iucode_tool.8.en#EXAMPLES) с микрокодом.

### Вывод

Считаю, что нужно убрать установку iucode-tool из раздела [Добавление важных модулей в образы ядра](https://ventureoo.github.io/ARU/source/first-steps.html#id7). Утилита нужна только для ручного взаимодействия с файлами микрокода Intel. С AMD она вообще не работает:
```
$ iucode_tool -S
iucode_tool: running on a non-Intel processor
```