### PR TITLE
file-systems: Add a demonstration of Btrfs file system compression

### DIFF
--- a/docs/source/Games List.md
+++ b/docs/source/Games List.md
@@ -1,0 +1,136 @@
+Далее представлен список протестированных игр на сжатие в файловой системе Btrfs. Данные были получены с помощью программы compsize и являются округленными, поэтому информация может нести частично ознакомительный характер.
+
+# Список протестированных игр
+
+ |№| Игра | Алгоритм | Уровень сжатия* | Необходимое место (N) | Используемое место(U) | U/N | Экономия |
+ | ---: | --- | :---: | :---: | :---: | :---: | :---: | :---: |
+ | 1 | A Plague Tale: Innocence | zstd | 15 | 41 GB | 41 GB | 99% | 306 MB |
+ | 2 | A Story About My Uncle | zstd | 15 | 1,1 GB | 1,1 GB | 93% | 74 MB |
+ | 3 | Aegis Defenders | zstd | 15 | 1,3 GB | 230 MB | 16% | 1,1 GB |
+ | 4 | Among Us | zstd | 15 | 429 MB | 279 MB | 65% | 150 MB | 
+ | 5 | Aragami | zstd | 15 | 7,6 GB | 5,3 GB | 69% | 2,27 GB |
+ | 6 | Armello | zstd | 15 | 1,6 GB | 1,5 GB | 94% | 83 MB |
+ | 7 | Bastion | zstd | 15 | 1,1 GB | 1,0 GB | 93% | 81 MB |
+ | 8 | BattleBlock Theater | zstd | 15 | 1,8 GB | 1,7 GB | 93% | 118,7 MB |
+ | 9 | Beholder | zstd | 15 | 1,9 GB | 1,1 GB | 58%| 843 MB |
+ | 10 | Beholder 2 | zstd | 15 | 2,5 GB | 2,1 GB | 81% | 483 MB |
+ | 11 | Blasphemous | zstd | 15 | 854 MB | 802 MB | 93% | 51 MB |
+ | 12 | Blue Fire | zstd | 15 | 6,0 GB | 4,7 GB | 77% | 1,3 GB |
+ | 13 | Brothers - A Tale of Two Sons | zstd | 15 | 1,2 GB | 1,1 GB | 95% | 52 MB |
+ | 14 | Castle Crashers | zstd | 15 | 199 MB | 183 MB | 91% | 15,8 MB |
+ | 15 | Celeste | zstd | 15 | 1,1 GB | 871 MB | 75% | 277 MB |
+ | 16 | Child of light | zstd | 15 | 2,3 GB | 2,3 GB | 99% | 9,5 MB |
+ | 17 | Children of Morta | zstd | 15 | 1,6 GB | 1,5 GB | 94% | 92 MB |
+ | 18 | CODE VEIN | zstd | 15 | 35 GB | 35 GB | 99% | 124 MB |
+ | 19 | Cortex Command | zstd | 15 | 97 MB | 64 MB | 66% | 33 MB |
+ | 20 | Cuphead | zstd | 15 | 3,6 GB | 3,3 GB | 93% | 233 MB |
+ | 21 | Curse of Dead Gods | zsrd | 15 | 2,7 GB | 1,4 GB | 51% | 1,29 GB |
+ | 22 | D-Corp | zstd | 15 | 1,2 GB | 697 MB | 55% | 549 MB |
+ | 23 | Dark Souls: Prepare To Die Edition | zstd | 15 | 3,7 GB | 3,7 GB | 99% | 1,61 MB |
+ | 24 | Dark Souls III | zstd | 15 | 24 GB | 24 GB | 99% | 0,6 MB |
+ | 25 | Darkest Dungeon | zstd | 15 | 3,2 GB | 2,8 GB | 87% | 410 MB |
+ | 26 | Darkestville Catle | zstd | 15 | 1,7 GB | 682 MB | 38% | 1,02 GB |
+ | 27 | Darksiders III | zstd | 15 | 24 GB | 24 GB | 99% | 30 MB |
+ | 28 | Dead Cells | zstd | 15 | 1,1 GB | 1,0 GB | 97% | 31 MB |
+ | 29 | Death's Door | zstd | 15 | 3,6 GB | 2,1 GB | 57% | 1,54 GB |
+ | 30 | Death's Gambit: Afterlife | zstd | 15 | 1 GB | 720 MB | 65% | 376 MB |
+ | 31 | Deponia: The Complete Journey | zstd | 15 | 9,5 GB | 9,5 GB | 99% | 25,6 MB |
+ | 32 | Devil May Cry 5 | zstd | 15 | 33 GB | 33 GB | 99% | 86 MB |
+ | 33 | Disco Elysium | zstd | 15 | 9,5 GB | 9,1 GB | 95% | 391 MB |
+ | 34 | Don't Starve Together | zstd | 15 | 2,5 GB | 1,8 GB | 73% | 679 MB |
+ | 35 | Eldest Souls | zstd | 15 | 1,0 GB |  708 MB | 68% | 326 MB |
+ | 36 | Evergate | zstd | 15 | 2,9 GB | 1,9 GB | 63% | 1,03 GB |
+ | 37 | Frostpunk | zstd | 15 | 8,9 GB | 8,9 GB | 99% | 25,2 MB |
+ | 38 | Furi | zstd | 15 | 4,3 GB | 2,7 GB | 63% | 1,52 GB |
+ | 39 | Gato Roboto | zstd | 15 | 440 MB | 414 MB | 94% | 26,1 MB |
+ | 40 | Gears Tactics | zstd | 15 | 29 GB | 29 GB | 99% | 97 MB |
+ | 41 | Ghost of a Tale | zstd | 15 | 4,7 GB | 3,7 GB | 79% | 0,94 GB |
+ | 42 | Ghostrunner | zstd | 15 | 24 GB | 20 GB | 84% | 3,7 GB |
+ | 43 | Gibbous - a Cthulhu Adventure | zstd | 15 | 9,0 GB | 4,1 GB | 46% | 4,87 GB |
+ | 44 | Gris | zstd | 15 | 3,2 GB | 1,5 GB | 46% | 1,73 GB |
+ | 45 | Hades | zstd | 15 | 11 GB | 10 GB | 95% | 498 MB |
+ | 46 | Hand of Fate | zstd | 15 | 2,5 GB | 2,2 GB | 89% | 287 MB |
+ | 47 | Hand of Fate 2 | zstd | 15 | 4,1 GB | 4,1 GB | 99% | 38 MB |
+ | 48 | Hellblade: Sanua's Sacrifice | zstd | 15 | 18 GB | 18 GB | 96% | 693 MB |
+ | 49 | Helldivers | zstd | 15 | 6,4 GB | 6,4 GB | 99% | 27 MB |
+ | 50 | Hob | zstd | 15 | 2,4 GB | 2,1 GB | 89% | 250 MB |
+ | 51 | Hollow Knight | zstd | 15 | 7,5 GB | 1,4 GB | 19% | 5,98 GB |
+ | 52 | Inmost | zstd | 15 | 1,3 GB | 638 MB | 47% | 720 MB |
+ | 53 | Jotun | zstd | 15 | 3,8 GB | 1,8 GB | 49% | 1,84 GB | 
+ | 54 | Journey | zstd | 15 | 3,3 GB | 1,9 GB | 56% | 1,44 GB |
+ | 55 | Katana ZERO | zstd | 15 | 216 MB | 177 MB | 81% | 39 MB |
+ | 56 | Kate | zstd | 15 | 254 MB | 100 MB | 39% | 155 MB |
+ | 57 | Limbo | zstd | 15 | 98 MB | 97 MB | 98% | 1,8 MB |
+ | 58 | Little Nightmare | zstd | 15 | 8,9 GB | 4,8 GB | 54% | 4,1 GB |
+ | 59 | Loop Hero | zstd | 15 | 140 MB | 115 MB | 82% | 23,9 MB |
+ | 60 | Magicka | zstd | 15 | 1,6 GB | 1,6 GB | 95% | 71 MB |
+ | 61 | Magicka 2 | zstd | 15 | 2,9 GB | 2,9 GB | 99% | 8,7 MB |
+ | 62 | Mark of the Ninja: Remastered | zstd | 15 | 7,5 GB | 6,9 GB | 92% | 591 MB |
+ | 63 | Master of Anima | zstd | 15 | 1,5 GB | 1,2 GB | 80% | 308 MB |
+ | 64 | METAL GEAR RISING: REVENGEANCE | zstd | 15 | 24 GB | 24 GB | 99% | 19,4 MB |
+ | 65 | Moonlighter | zstd | 15 | 1,1 GB | 572 MB | 48% | 613 MB |
+ | 66 | Move or Die | zstd | 15 | 666 MB | 567 MB | 85% | 99 MB |
+ | 67 | My Friend Pedro | zstd | 15 | 3,5 GB | 2,9 GB | 81% | 666 MB |
+ | 68 | Nier:Automata | zstd | 15 | 40 GB | 37 GB | 91% | 3,3 GB |
+ | 69 | Nine Parchments | zstd | 15 | 5,7 GB | 5,7 GB | 98% | 78 MB |
+ | 70 | Ori and the Blind Forest: Definitive Edition | zstd | 15 | 10 GB | 4,7 GB | 46% | 5,5 GB |
+ | 71 | Ori and the Will of the Wisps | zstd | 15 | 11 GB | 5,3 GB | 46% | 6,1 GB |
+ | 72 | Othercide | zstd | 15 | 6,0 GB | 5,9 GB | 98% | 113 MB |
+ | 73 | Out of Line | zstd | 15 | 1,3 GB | 476 MB | 35% | 857 MB |
+ | 74 | Outland | zstd | 15 | 675 MB | 589 MB | 87% | 86 MB |
+ | 75 | Overcooked! 2 | zstd | 15 | 7,9 GB | 7,7 GB | 87% | 169 MB |
+ | 76 | Papers, Please | zstd | 15 | 58 MB | 44 MB | 76% | 13,6 MB |
+ | 77 | Path of Exile | zstd | 15 | 27 GB | 27 GB | 99% | 29 MB |
+ | 78 | Peace, Death! | zstd | 15 | 83 MB | 76 MB | 91% | 7,5 MB |
+ | 79 | Peace, Death! 2 | zstd | 15 | 34 MB | 26 MB | 78% | 7,51 MB |
+ | 80 | Pummel Party | zstd | 15 | 2,1 GB | 1,4 GB | 66% | 723 MB |
+ | 81 | Remember Me | zstd | 15 | 6,7 GB | 6,6 GB | 99% | 58 MB |
+ | 82 | Rocket League | zstd | 15 | 18 GB | 18 GB | 99% | 46 MB |
+ | 83 | RUINER | zstd | 15 | 10 GB | 10 GB | 99% | 77 MB |
+ | 84 | Salt and Sanctuary | zstd | 15 | 563 MB | 540 MB | 95% | 24 MB |
+ | 85 | Samorost 1 | zstd | 15 | 68 MB | 68 MB | 99% | 23 KB |
+ | 86 | Samorost 2 | zstd | 15 | 141 MB | 140 MB | 98% | 1,33 MB |
+ | 87 | Samorost 3 | zstd | 15 | 1,1 GB | 1,0 GB | 96% | 43 MB |
+ | 88 | Sekiro: Shadow Die Twice | zstd | 15 | 13 GB | 13 GB | 99% | 1,6 MB |
+ | 89 | Severed Steel | zstd | 15 | 4,0 GB | 2,7 GB | 67% | 1,26 GB |
+ | 90 | Shadow Tactics: Blades of the Shogun | zstd | 15 | 7,3 GB | 4,8 GB | 66% | 2,5 GB |
+ | 91 | Shadowrun Returns | zstd | 15 | 2,8 GB | 1,0 GB | 37% | 1,74 GB |
+ | 92 | Shattered - Tale of the Forgotten King | zstd | 15 | 6,3 GB | 6,3 GB | 99% | 15,7 MB |
+ | 93 | Shiro | zstd | 15 | 80 MB | 73 MB | 91% | 6,7 MB |
+ | 94 | Skul: The Hero Slayer | zstd | 15 | 1016 MB | 987 MB | 97% | 29 MB |
+ | 95 | SpeedRunners | zstd | 15 | 662 MB | 650 MB | 98% | 12 MB |
+ | 96 | Spiritfarer: Farewell | zstd | 15 | 6,0 GB | 2,3 GB | 39% | 3,58 GB |
+ | 97 | Stoneshard: Prologue | zstd | 15 | 289 MB | 260 MB | 89% | 28,4 GB |
+ | 98 | Stories: The Path of Destinies | zstd | 15 | 1,6 GB | 1,6 GB | 99% | 14,8 MB |
+ | 99 | Styx: Master of Shadow | zstd | 15 | 6,7 GB | 6,6 GB | 98% | 114 MB |
+ | 100 | Styx: Shards of Darkness | zstd | 15 | 10 GB | 10 GB | 99% | 22,9 MB |
+ | 101 | Sundered: Eldritch Edition | zstd | 15 | 2,2 GB | 1,5 GB | 69% | 719 MB |
+ | 102 | SYNTHETIK | zstd | 15 | 599 MB | 516 MB | 86% | 83 MB |
+ | 103 | Tabletop Simulator | zstd | 15 | 2,7 GB | 1,7GB | 63% | 0,95 GB |
+ | 104 | The Escapists 2 | zstd | 15 | 2,4 GB | 1,7 GB | 71% | 717 MB |
+ | 105 | The Life and Suffering of Sir Brante | zstd | 15 | 2,7 GB | 1,1 GB | 43% | 1,48 GB |
+ | 106 | The Cave | zstd | 15 | 1,1 GB | 1,1 GB | 98% | 24 MB |
+ | 107 | The Red Solstice | zstd | 15 | 2,7 GB | 1,4 GB | 51% | 1,34 GB |
+ | 108 | They Always Run | zstd | 15 | 10 GB | 3,8 GB | 34% | 7,1 GB |
+ | 109 | This War of Mine | zstd | 15 | 2,6 GB | 2,5 GB | 98% | 36 MB |
+ | 110 | Titan Souls | zstd | 15 | 206 MB | 182 MB | 88% | 22,5 MB |
+ | 111 | Transistor | zstd | 15 | 3,0 GB | 2,7 GB | 87% | 384 MB |
+ | 112 | Trine | zstd | 15 | 1,3 GB | 1,3 GB | 96% | 44 MB |
+ | 113 | Undertale | zstd | 15 | 155 MB | 140 MB | 90% | 14,9 MB |
+ | 114 | Valiant Hearts: The Great War | zstd | 15 | 1,2 GB | 1,1 GB | 99% | 10,2 MB |
+ | 115 | Vanquish | zstd | 15 | 18 GB | 18 GB | 99% | 12,3 MB |
+ | 116 | Vesper | zstd | 15 | 2,8 GB | 964 MB | 32% | 1,92 GB |
+ | 117 | Void Bastards | zstd | 15 | 5,7 GB | 2,3 GB | 41% | 3,28 GB |
+ | 118 | Wasteland 2: Director's Cut | zstd | 15 | 14 GB | 13 GB | 91% | 1.1 GB |
+ | 119 | Wasteland 3 | zstd | 15 | 26 GB | 23 GB | 89% | 2,71 GB |
+ | 120 | Witch It | zsta | 15 | 4,2 GB | 4,1 GB | 97% | 95 MB |
+ | 121 | Wizard of Legend | zstd | 15 | 786 MB | 468 MB | 59% | 318 MB |
+ |  | | | | | |  | |
+ | `Итого` | | `zstd` | `15` | `742 GB` | `645 GB` | `86%` | `97 GB` |
+
+
+Примечания:
+
+\*Уровень сжатия - 15 - для алгоритма zstd на данный момент является максимально доступным в файловой системе Btrfs.
+
+По возможности данный список будет расширяться новыми играми и другими алгоритмами сжатия.


### PR DESCRIPTION
Список протестированных мной игр. В качестве носителя использовался SATA SSD Samsung 860 EVO на 1 ТБ. Информация постепенно будет добавляться.

Part-of: https://github.com/ventureoo/ARU/pull/45